### PR TITLE
Update Dockerfile to disable java11 plugins for cloudera release 

### DIFF
--- a/docker/ubi8/Dockerfile
+++ b/docker/ubi8/Dockerfile
@@ -13,18 +13,18 @@ RUN useradd spinnaker
 RUN mkdir -p /opt/orca/plugins
 
 #custom plugin zip files adding
-ARG CUSTOMPLUGIN_RELEASEVERSION
-ENV CUSTOMPLUGIN_RELEASEVERSION=$CUSTOMPLUGIN_RELEASEVERSION
-RUN wget -O Opsmx.VerificationGatePlugin-VerificationPlugin-v1.0.1-SNAPSHOT.zip -c https://github.com/OpsMx/Customplugins/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/VerificationPlugin-v1.0.1-SNAPSHOT.zip -P /opt/orca/plugins \
-    && wget -O Opsmx.TestVerificationGatePlugin-TestVerificationPlugin-v1.0.1-SNAPSHOT.zip -c https://github.com/OpsMx/Customplugins/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/TestVerificationPlugin-v1.0.1-SNAPSHOT.zip -P /opt/orca/plugins \
-    && wget -O Opsmx.PolicyGatePlugin-policyPlugin-v1.0.1-SNAPSHOT.zip -c https://github.com/OpsMx/Customplugins/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/policyPlugin-v1.0.1-SNAPSHOT.zip -P /opt/orca/plugins \
-    && wget -O Opsmx.PolicyGatePlugin-RbacPlugin-v1.0.1-SNAPSHOT.zip -c https://github.com/OpsMx/Customplugins/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/RbacPlugin-v1.0.1-SNAPSHOT.zip -P /opt/orca/plugins \    
-    && wget -O Opsmx.VisibilityApprovalPlugin-ApprovalStagePlugin-v1.0.1-SNAPSHOT.zip -c https://github.com/OpsMx/Customplugins/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/ApprovalStagePlugin-v1.0.1-SNAPSHOT.zip -P /opt/orca/plugins
-RUN mv Opsmx.VerificationGatePlugin-VerificationPlugin-v1.0.1-SNAPSHOT.zip /opt/orca/plugins/ \
-    && mv Opsmx.TestVerificationGatePlugin-TestVerificationPlugin-v1.0.1-SNAPSHOT.zip /opt/orca/plugins/ \
-    && mv Opsmx.PolicyGatePlugin-policyPlugin-v1.0.1-SNAPSHOT.zip /opt/orca/plugins/ \
-    && mv Opsmx.PolicyGatePlugin-RbacPlugin-v1.0.1-SNAPSHOT.zip /opt/orca/plugins/ \
-    && mv Opsmx.VisibilityApprovalPlugin-ApprovalStagePlugin-v1.0.1-SNAPSHOT.zip /opt/orca/plugins/
+#ARG CUSTOMPLUGIN_RELEASEVERSION
+#ENV CUSTOMPLUGIN_RELEASEVERSION=$CUSTOMPLUGIN_RELEASEVERSION
+#RUN wget -O Opsmx.VerificationGatePlugin-VerificationPlugin-v1.0.1-SNAPSHOT.zip -c https://github.com/OpsMx/Customplugins/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/VerificationPlugin-v1.0.1-SNAPSHOT.zip -P /opt/orca/plugins \
+#    && wget -O Opsmx.TestVerificationGatePlugin-TestVerificationPlugin-v1.0.1-SNAPSHOT.zip -c https://github.com/OpsMx/Customplugins/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/TestVerificationPlugin-v1.0.1-SNAPSHOT.zip -P /opt/orca/plugins \
+#    && wget -O Opsmx.PolicyGatePlugin-policyPlugin-v1.0.1-SNAPSHOT.zip -c https://github.com/OpsMx/Customplugins/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/policyPlugin-v1.0.1-SNAPSHOT.zip -P /opt/orca/plugins \
+#    && wget -O Opsmx.PolicyGatePlugin-RbacPlugin-v1.0.1-SNAPSHOT.zip -c https://github.com/OpsMx/Customplugins/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/RbacPlugin-v1.0.1-SNAPSHOT.zip -P /opt/orca/plugins \    
+#    && wget -O Opsmx.VisibilityApprovalPlugin-ApprovalStagePlugin-v1.0.1-SNAPSHOT.zip -c https://github.com/OpsMx/Customplugins/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/ApprovalStagePlugin-v1.0.1-SNAPSHOT.zip -P /opt/orca/plugins
+#RUN mv Opsmx.VerificationGatePlugin-VerificationPlugin-v1.0.1-SNAPSHOT.zip /opt/orca/plugins/ \
+#    && mv Opsmx.TestVerificationGatePlugin-TestVerificationPlugin-v1.0.1-SNAPSHOT.zip /opt/orca/plugins/ \
+#    && mv Opsmx.PolicyGatePlugin-policyPlugin-v1.0.1-SNAPSHOT.zip /opt/orca/plugins/ \
+#    && mv Opsmx.PolicyGatePlugin-RbacPlugin-v1.0.1-SNAPSHOT.zip /opt/orca/plugins/ \
+#    && mv Opsmx.VisibilityApprovalPlugin-ApprovalStagePlugin-v1.0.1-SNAPSHOT.zip /opt/orca/plugins/
 
 RUN chmod -R 777 /opt/orca/plugins/
 RUN chown -R spinnaker:spinnaker /opt/


### PR DESCRIPTION
Disable plugins which are compiled in java11 for Cloudera release, as they use only OSS spinnaker, and do not require ISD currently.   