### PR TITLE
Fixed sql-test error due to mysql-connector version

### DIFF
--- a/keiko-sql/keiko-sql.gradle
+++ b/keiko-sql/keiko-sql.gradle
@@ -20,5 +20,5 @@ dependencies {
   testImplementation project(":keiko-tck")
   testImplementation "io.spinnaker.kork:kork-sql-test"
   testImplementation "org.testcontainers:mysql"
-  testImplementation "mysql:mysql-connector-java"
+  testImplementation "mysql:mysql-connector-java:8.0.33"
 }


### PR DESCRIPTION
SQL tests are failing earlier, giving error : Could not find mysql:mysql-connector-java
By this change, this error got resolved.
Jira : https://devopsmx.atlassian.net/browse/OP-20334