### PR TITLE
Fixed mysql-connector issue in keiko-sql testcase

### DIFF
--- a/keiko-sql/keiko-sql.gradle
+++ b/keiko-sql/keiko-sql.gradle
@@ -20,5 +20,5 @@ dependencies {
   testImplementation project(":keiko-tck")
   testImplementation "io.spinnaker.kork:kork-sql-test"
   testImplementation "org.testcontainers:mysql"
-  testImplementation "mysql:mysql-connector-java:8.0.33"
+  testImplementation "mysql:mysql-connector-java:8.0.20"
 }


### PR DESCRIPTION
Due to version conflicts, it is unable to find this dependency.
By moving to v8.0.20, this error is gone