### PR TITLE
Fixed orca-bakery TCs by adding junit4

### DIFF
--- a/orca-bakery/orca-bakery.gradle
+++ b/orca-bakery/orca-bakery.gradle
@@ -37,6 +37,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core:2.25.0")
+  testImplementation("junit:junit")
 
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
 }


### PR DESCRIPTION
## Summary
Project Jira : https://devopsmx.atlassian.net/browse/OP-20334
Project Doc : NA

Issue : Junit4 is missing in Orca-bakery module but TC uses Junit4 classes (i.e. Test, Rule)
Solution : Added Junit4 dependency in Orca-bakery.gradle. We can use Junit5 Test's class but there is no Rule class in Junit5. 

### How changes are verified
./gradlew orca-bakery:test -> successful
It will not impact any other service/module.
Added dependency is latest and vulnerability-free : [Ref](https://mvnrepository.com/artifact/junit/junit)

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

### Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
Pre deployment steps : NA
Post deployment steps : NA