### PR TITLE
fix for destroyservergroupstage giving exception

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.ForceCacheRefreshAware
@@ -33,7 +34,7 @@ import org.springframework.stereotype.Component
 @Component
 class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport implements ForceCacheRefreshAware {
   private static final Logger log = LoggerFactory.getLogger(DestroyServerGroupStage.class)
-  
+
   static final String PIPELINE_CONFIG_TYPE = "destroyServerGroup"
 
   private final DynamicConfigService dynamicConfigService
@@ -47,11 +48,11 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport implem
     boolean skipDisable = (boolean)context.getOrDefault("skipDisableBeforeDestroy", false)
 
     if (!skipDisable) {
-      // conditional opt-out for server groups where an explicit disable is unnecessary 
+      // conditional opt-out for server groups where an explicit disable is unnecessary
       // (ie. they do not register in service discovery or a load balancer)
       graph.add {
         it.name = "disableServerGroup"
-        it.type = getType(DisableServerGroupStage)
+        it.type = StageDefinitionBuilder.getType(DisableServerGroupStage)
         it.context.putAll(context)
       }
     } else {


### PR DESCRIPTION
Summary
Project Jira : [https://devopsmx.atlassian.net/browse/OP-20619](url)
Project Doc : NA

Issue : destroy server group stage  for aws is failing with below exception:
![image](https://github.com/OpsMx/orca-oes/assets/93190458/b212edad-e01b-4574-921e-0bce1398b354)

Solution : In  method addDisableStage of class DestroyServerGroupStage , getType() method from StageDefinitionBuilder is not identified by the groovy code.on adding full reference StageDefinitionBuilder.getType(DisableServerGroupStage) the issue can be fixed.

How changes are verified

gradle build - successful
Need to test the image generated after PR merge

Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

Rollback, Deployment Details
Can this change be rolled back automatically without any issue? Yes
Is this a backwards-compatible change in your opinion ? Yes
Pre deployment steps : NA
Post deployment steps : QA need to cross verify whether functionality is breaking or not