### PR TITLE
Added mapNotnull and maxOrNull to handle completedPipelineKeys in Pee…

### DIFF
--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
@@ -255,7 +255,7 @@ class PeeringAgent(
       .map { it.id }
 
     fun getLatestCompletedUpdatedTime() =
-      (completedPipelineKeys.map { it.updated_at }.max() ?: updatedAfter)
+      (completedPipelineKeys.mapNotNull { it.updated_at }.maxOrNull() ?: updatedAfter)
 
     if (pipelineIdsToDelete.isEmpty() && pipelineIdsToMigrate.isEmpty()) {
       log.debug("No completed $executionType executions to copy for peering")


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20795)
**Project Doc :** NA

**Issue :** 6/42 TCs failing in orca-peering
```
java.util.NoSuchElementException
	at kotlin.collections.CollectionsKt___CollectionsKt.maxOrThrow(_Collections.kt:1916)
	at com.netflix.spinnaker.orca.peering.PeeringAgent.doMigrate$getLatestCompletedUpdatedTime(PeeringAgent.kt:258)
	at com.netflix.spinnaker.orca.peering.PeeringAgent.doMigrate(PeeringAgent.kt:280)
	at com.netflix.spinnaker.orca.peering.PeeringAgent.peerCompletedExecutions(PeeringAgent.kt:168)
	at com.netflix.spinnaker.orca.peering.PeeringAgentSpec.correctly computes the execution diff for completed #executionType(PeeringAgentSpec.groovy:91)
```
**Solution :** By using mapNotNull and maxOrNull, we ensure that the code gracefully handles the case when completedPipelineKeys is empty or when there are null values in the updated_at properties

### How changes are verified
build successful & 42/42 TCs are passing in orca-peering

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** NA