### PR TITLE
Removed explicit json-path dependency version & fixed orca-core TCs

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -53,7 +53,7 @@ dependencies {
   implementation("org.apache.httpcomponents:httpclient")
   implementation("jakarta.servlet:jakarta.servlet-api:+")
   implementation("javax.validation:validation-api:+")
-  implementation("com.jayway.jsonpath:json-path:2.2.0")
+  implementation("com.jayway.jsonpath:json-path")
   implementation("org.yaml:snakeyaml")
   implementation("org.apache.groovy:groovy:4.0.9")
   implementation("org.jetbrains.spek:spek-api:1.1.5")

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -452,7 +452,7 @@ class ContextParameterProcessorSpec extends Specification {
     def result = contextParameterProcessor.process(source, contextParameterProcessor.buildExecutionContext(execution), true)
 
     then:
-    result.deployed.size == 2
+    result.deployed.size() == 2
     result.deployed.serverGroup == ["flex-test-v043", "flex-prestaging-v011"]
     result.deployed.region == ["us-east-1", "us-west-1"]
     result.deployed.ami == ["ami-06362b6e", "ami-f759b7b3"]
@@ -601,7 +601,7 @@ class ContextParameterProcessorSpec extends Specification {
     def result = contextParameterProcessor.process(source, contextParameterProcessor.buildExecutionContext(execution), true)
 
     then:
-    result.deployed.size == 2
+    result.deployed.size() == 2
     result.deployed.serverGroup == ["flex-test-v043", "flex-prestaging-v011"]
     result.deployed.region == ["us-east-1", "us-west-1"]
     result.deployed.ami == ["ami-06362b6e", "ami-f759b7b3"]
@@ -612,7 +612,7 @@ class ContextParameterProcessorSpec extends Specification {
     result = contextParameterProcessor.process(source, contextParameterProcessor.buildExecutionContext(execution), true)
 
     then: 'should only consider the specified stage name/id'
-    result.deployed.size == 1
+    result.deployed.size() == 1
     result.deployed.serverGroup == ["flex-test-v043"]
     result.deployed.region == ["us-east-1"]
     result.deployed.ami == ["ami-06362b6e"]

--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -10,7 +10,7 @@ dependencies {
   implementation("com.hubspot.jinjava:jinjava")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-  implementation("com.jayway.jsonpath:json-path:2.2.0")
+  implementation("com.jayway.jsonpath:json-path")
   implementation("org.slf4j:slf4j-api")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("org.springframework:spring-context")

--- a/orca-webhook/orca-webhook.gradle
+++ b/orca-webhook/orca-webhook.gradle
@@ -25,7 +25,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")
-  implementation("com.jayway.jsonpath:json-path:2.2.0")
+  implementation("com.jayway.jsonpath:json-path")
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
 //  testImplementation project(':orca-test')


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-21632)
**Project Doc :** NA

**Issue :** Dependency coming from kork-bom
**Solution :** No need to put explicit version in .gradle files

### How changes are verified
orca build successful, no new TCs failing in core, webhook, pipelinetemplate

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** QA need to do regression testing